### PR TITLE
Fix run-on-blame ignoring standards file

### DIFF
--- a/src/run-on-blame.ts
+++ b/src/run-on-blame.ts
@@ -14,7 +14,8 @@ export async function runOnBlame(files: string[]): Promise<void> {
 
     const lintResults = await lint(
       files,
-      core.getInput('phpcs_path', { required: true })
+      core.getInput('phpcs_path', { required: true }),
+      options
     );
 
     const dontFailOnWarning =


### PR DESCRIPTION
This fixes https://github.com/tinovyatkin/action-php-codesniffer/issues/40. I hope, I'm a bit unsure whether the path should first be unresolved to an absolute path, or whether that is not required.

Btw, I didn't get to run this locally so couldn't test if this works. If you have some contributing / local development advice, I'm open!